### PR TITLE
Fix the schedule header column on devices with low height

### DIFF
--- a/live-css/live-css-wceu-2024.css
+++ b/live-css/live-css-wceu-2024.css
@@ -858,6 +858,11 @@ table.tix_tickets_table.tix-tickets-list {
 	font: 20px/32px 'Krona One', sans-serif;
 	padding: 54px 69px !important;
 }
+@media ( min-height: 1000px ) {
+	.wordcamp-schedule .wordcamp-schedule__column-header {
+		padding: 54px 69px !important;
+	}
+}
 
 .wordcamp-schedule__time-slot-header {
 	background-color: #FDE0AD !important;


### PR DESCRIPTION
On devices with a low height, the fixed positioned header column might take up more than half the screen size, making the schedule unusable on those devices.

This fix will also set that large padding - why is that there in the first place - if the `min-height` is at least `1000px`, fixing that issue on those devices.

Here is an example of a smartphone in landscape mode:

![image](https://github.com/wceu/wceu2024/assets/1793177/309d814d-8da6-4458-a318-62e699996242)


And here is an image of a Dell XPS laptop with 720px total display height:

![image](https://github.com/wceu/wceu2024/assets/1793177/7e728c92-5362-4d84-8a85-055d1d47a1dd)
